### PR TITLE
Update for new web push

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,12 @@ Next publish the migration with:
 php artisan vendor:publish --provider="NotificationChannels\WebPush\WebPushServiceProvider" --tag="migrations"
 ```
 
+If you are using UUID for primary key of users table you can use:
+
+``` bash
+php artisan vendor:publish --provider="NotificationChannels\WebPush\WebPushServiceProvider" --tag="uuid-migrations"
+```
+
 Run the migrate command to create the necessary table:
 
 ``` bash

--- a/migrations/create_push_subscriptions_uuid_table.php.stub
+++ b/migrations/create_push_subscriptions_uuid_table.php.stub
@@ -15,7 +15,7 @@ class CreatePushSubscriptionsTable extends Migration
     {
         Schema::connection(config('webpush.database_connection'))->create(config('webpush.table_name'), function (Blueprint $table) {
             $table->bigIncrements('id');
-            $table->morphs('subscribable');
+            $table->uuidMorphs('subscribable');
             $table->string('endpoint', 500)->unique();
             $table->string('keys', 500)->nullable();
             $table->string('content_encoding')->nullable();

--- a/src/HasPushSubscriptions.php
+++ b/src/HasPushSubscriptions.php
@@ -18,20 +18,19 @@ trait HasPushSubscriptions
      * Update (or create) subscription.
      *
      * @param  string  $endpoint
-     * @param  string|null  $key
-     * @param  string|null  $token
+     * @param  string|null  $keys
      * @param  string|null  $contentEncoding
      * @return \NotificationChannels\WebPush\PushSubscription
      */
-    public function updatePushSubscription($endpoint, $key = null, $token = null, $contentEncoding = null)
+    public function updatePushSubscription($endpoint, $keys = null, $contentEncoding = null)
     {
         $subscription = app(config('webpush.model'))->findByEndpoint($endpoint);
 
         if ($subscription && $this->ownsPushSubscription($subscription)) {
-            $subscription->public_key = $key;
-            $subscription->auth_token = $token;
-            $subscription->content_encoding = $contentEncoding;
-            $subscription->save();
+            $subscription->update([
+                'keys' => $keys,
+                'content_encoding' => $contentEncoding
+            ]);
 
             return $subscription;
         }
@@ -42,8 +41,7 @@ trait HasPushSubscriptions
 
         return $this->pushSubscriptions()->create([
             'endpoint' => $endpoint,
-            'public_key' => $key,
-            'auth_token' => $token,
+            'keys' => $keys,
             'content_encoding' => $contentEncoding,
         ]);
     }

--- a/src/HasPushSubscriptions.php
+++ b/src/HasPushSubscriptions.php
@@ -29,7 +29,7 @@ trait HasPushSubscriptions
         if ($subscription && $this->ownsPushSubscription($subscription)) {
             $subscription->update([
                 'keys' => $keys,
-                'content_encoding' => $contentEncoding
+                'content_encoding' => $contentEncoding,
             ]);
 
             return $subscription;

--- a/src/PushSubscription.php
+++ b/src/PushSubscription.php
@@ -20,8 +20,7 @@ class PushSubscription extends Model
      */
     protected $fillable = [
         'endpoint',
-        'public_key',
-        'auth_token',
+        'keys',
         'content_encoding',
     ];
 

--- a/src/WebPushChannel.php
+++ b/src/WebPushChannel.php
@@ -52,12 +52,17 @@ class WebPushChannel
 
         /** @var \NotificationChannels\WebPush\PushSubscription $subscription */
         foreach ($subscriptions as $subscription) {
-            $this->webPush->queueNotification(new Subscription(
-                $subscription->endpoint,
-                $subscription->public_key,
-                $subscription->auth_token,
-                $subscription->content_encoding
-            ), $payload, $options);
+            $this->webPush->queueNotification(
+                Subscription::create(
+                    [
+                        'endpoint' => $subscription->endpoint,
+                        'keys' => json_decode($subscription->keys, true),
+                        'contentEncoding' => $subscription->content_encoding
+                    ]
+                ),
+                $payload,
+                $options
+            );
         }
 
         $reports = $this->webPush->flush();

--- a/src/WebPushChannel.php
+++ b/src/WebPushChannel.php
@@ -57,7 +57,7 @@ class WebPushChannel
                     [
                         'endpoint' => $subscription->endpoint,
                         'keys' => json_decode($subscription->keys, true),
-                        'contentEncoding' => $subscription->content_encoding
+                        'contentEncoding' => $subscription->content_encoding,
                     ]
                 ),
                 $payload,

--- a/src/WebPushServiceProvider.php
+++ b/src/WebPushServiceProvider.php
@@ -99,6 +99,10 @@ class WebPushServiceProvider extends ServiceProvider
             $this->publishes([
                 __DIR__.'/../migrations/create_push_subscriptions_table.php.stub' => database_path("migrations/{$timestamp}_create_push_subscriptions_table.php"),
             ], 'migrations');
+
+            $this->publishes([
+                __DIR__.'/../migrations/create_push_subscriptions_uuid_table.php.stub' => database_path("migrations/{$timestamp}_create_push_subscriptions_table.php"),
+            ], 'uuid-migrations');
         }
     }
 }

--- a/tests/ChannelTest.php
+++ b/tests/ChannelTest.php
@@ -31,8 +31,6 @@ class ChannelTest extends TestCase
             ->withArgs(function (Subscription $subscription, string $payload, array $options = [], array $auth = []) use ($message) {
                 $this->assertInstanceOf(Subscription::class, $subscription);
                 $this->assertEquals('endpoint', $subscription->getEndpoint());
-                $this->assertEquals('key', $subscription->getPublicKey());
-                $this->assertEquals('token', $subscription->getAuthToken());
                 $this->assertEquals('aesgcm', $subscription->getContentEncoding());
                 $this->assertSame($message->getOptions(), $options);
                 $this->assertSame(json_encode($message->toArray()), $payload);
@@ -47,7 +45,7 @@ class ChannelTest extends TestCase
                 yield new MessageSentReport(new Request('POST', 'endpoint'), null, true);
             })());
 
-        $this->testUser->updatePushSubscription('endpoint', 'key', 'token', 'aesgcm');
+        $this->testUser->updatePushSubscription('endpoint', 'keys', 'aesgcm');
 
         $channel->send($this->testUser, $notification);
 

--- a/tests/HasPushSubscriptionsTest.php
+++ b/tests/HasPushSubscriptionsTest.php
@@ -18,25 +18,23 @@ class HasPushSubscriptionsTest extends TestCase
     /** @test */
     public function subscription_can_be_created()
     {
-        $this->testUser->updatePushSubscription('foo', 'key', 'token', 'aesgcm');
+        $this->testUser->updatePushSubscription('foo', 'keys', 'aesgcm');
         $subscription = $this->testUser->pushSubscriptions()->first();
 
         $this->assertEquals('foo', $subscription->endpoint);
-        $this->assertEquals('key', $subscription->public_key);
-        $this->assertEquals('token', $subscription->auth_token);
+        $this->assertEquals('keys', $subscription->keys);
         $this->assertEquals('aesgcm', $subscription->content_encoding);
     }
 
     /** @test */
     public function exiting_subscription_can_be_updated_by_endpoint()
     {
-        $this->testUser->updatePushSubscription('foo', 'key', 'token');
-        $this->testUser->updatePushSubscription('foo', 'major-key', 'another-token');
+        $this->testUser->updatePushSubscription('foo', 'keys', 'aesgcm');
+        $this->testUser->updatePushSubscription('foo', 'major-keys', 'aesgcm');
         $subscriptions = $this->testUser->pushSubscriptions()->where('endpoint', 'foo')->get();
 
         $this->assertEquals(1, count($subscriptions));
-        $this->assertEquals('major-key', $subscriptions[0]->public_key);
-        $this->assertEquals('another-token', $subscriptions[0]->auth_token);
+        $this->assertEquals('major-keys', $subscriptions[0]->keys);
     }
 
     /** @test */

--- a/tests/PushSubscriptionModelTest.php
+++ b/tests/PushSubscriptionModelTest.php
@@ -11,14 +11,12 @@ class PushSubscriptionModelTest extends TestCase
     {
         $subscription = new PushSubscription([
             'endpoint' => 'endpoint',
-            'public_key' => 'key',
-            'auth_token' => 'token',
+            'keys' => 'keys',
             'content_encoding' => 'aesgcm',
         ]);
 
         $this->assertEquals('endpoint', $subscription->endpoint);
-        $this->assertEquals('key', $subscription->public_key);
-        $this->assertEquals('token', $subscription->auth_token);
+        $this->assertEquals('keys', $subscription->keys);
         $this->assertEquals('aesgcm', $subscription->content_encoding);
     }
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -79,8 +79,7 @@ abstract class TestCase extends Orchestra
         return $user->pushSubscriptions()->create([
             'user_id' => $user->id,
             'endpoint' => $endpoint,
-            'public_key' => 'key',
-            'auth_token' => 'token',
+            'keys' => 'keys',
         ]);
     }
 


### PR DESCRIPTION
Currently browser support **newSubscription**, so I create new PR to handle new keys for web push.
[new web push](https://w3c.github.io/push-api/#push-subscription)

Task:
+ Update migrate file -> remove old key, update to new keys, add option UUID
+ Add option UUID on document
+ Update ```send``` method on ```src/WebPushChannel.php``` to allow insert by new key
+ Update test script
